### PR TITLE
Added Reflection classes and related tests, which acccess the class o…

### DIFF
--- a/Reflection/Reflection/Reflection.sln
+++ b/Reflection/Reflection/Reflection.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.24720.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Reflection", "Reflection\Reflection.csproj", "{8BD4A077-237B-4E0D-A7FA-8ADF53655668}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReflectionTests", "ReflectionTests\ReflectionTests.csproj", "{94EDFBC2-4ACD-42B7-BA05-76A6ACA14C85}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8BD4A077-237B-4E0D-A7FA-8ADF53655668}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8BD4A077-237B-4E0D-A7FA-8ADF53655668}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8BD4A077-237B-4E0D-A7FA-8ADF53655668}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8BD4A077-237B-4E0D-A7FA-8ADF53655668}.Release|Any CPU.Build.0 = Release|Any CPU
+		{94EDFBC2-4ACD-42B7-BA05-76A6ACA14C85}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{94EDFBC2-4ACD-42B7-BA05-76A6ACA14C85}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{94EDFBC2-4ACD-42B7-BA05-76A6ACA14C85}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{94EDFBC2-4ACD-42B7-BA05-76A6ACA14C85}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/Reflection/Reflection/Reflection/Bottle.cs
+++ b/Reflection/Reflection/Reflection/Bottle.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Security.Policy;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Reflection
+{
+    /// <summary>
+    /// A container used for storing liquids.
+    /// </summary>
+    public class Bottle
+    {
+        /// <summary>
+        /// This bool is True if the bottle is full.
+        /// </summary>
+        public bool IsFull { get; set; }
+
+        /// <summary>
+        /// The Liquid continaed in the bottle.
+        /// </summary>
+        public string Liquid { get; set; }
+
+
+        /// <summary>
+        /// Fills the bottle with the specified liquid.
+        /// </summary>
+        public string Fill()
+        {
+            if (IsFull)
+            {
+                return "The liquid spills all over the floor...";
+            }
+            else
+            {
+                IsFull = true;
+                return $"You have filled the bottle with {Liquid}!";
+            }
+        }
+
+    }
+}

--- a/Reflection/Reflection/Reflection/Properties/AssemblyInfo.cs
+++ b/Reflection/Reflection/Reflection/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Reflection")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Reflection")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("8bd4a077-237b-4e0d-a7fa-8adf53655668")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Reflection/Reflection/Reflection/Reflection.csproj
+++ b/Reflection/Reflection/Reflection/Reflection.csproj
@@ -1,0 +1,55 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{8BD4A077-237B-4E0D-A7FA-8ADF53655668}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Reflection</RootNamespace>
+    <AssemblyName>Reflection</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Bottle.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Stamp.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Reflection/Reflection/Reflection/Stamp.cs
+++ b/Reflection/Reflection/Reflection/Stamp.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Policy;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Reflection
+{
+    /// <summary>
+    /// An object used to place ink or other patterns on a medium.
+    /// </summary>
+    public class Stamp
+    {
+        /// <summary>
+        /// Wether 
+        /// </summary>
+        public bool IsInked { get; set; }
+
+        /// <summary>
+        /// The message the stamp was made to print.
+        /// </summary>
+        public string Message { get; set; }
+
+
+        /// <summary>
+        /// Stamps the Message in the console if the stamp is inked.
+        /// </summary>
+        public string StampMessage()
+        {
+            return IsInked ? Message : "";
+        }
+
+    }
+}

--- a/Reflection/Reflection/ReflectionTests/BottleReflectionTests.cs
+++ b/Reflection/Reflection/ReflectionTests/BottleReflectionTests.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Reflection;
+
+namespace ReflectionTests
+{
+    [TestClass]
+    public class BottleReflectionTests
+    {
+        [TestMethod]
+        public void Bottle_Can_Be_Constructed()
+        {
+            Bottle bottle = Activator.CreateInstance(typeof(Bottle)) as Bottle;
+            Assert.IsInstanceOfType(bottle, typeof(Bottle));
+        }
+
+        [TestMethod]
+        public void Bottle_Can_Write_IsInked()
+        {
+            var propertyInfo = typeof(Bottle).GetProperty("IsFull");
+            Assert.IsTrue(propertyInfo.CanWrite);
+        }
+
+        [TestMethod]
+        public void Bottle_Can_Read_IsInked()
+        {
+            var propertyInfo = typeof(Bottle).GetProperty("IsFull");
+            Assert.IsTrue(propertyInfo.CanRead);
+        }
+
+        [TestMethod]
+        public void Bottle_Can_Read_Message()
+        {
+            var propertyInfo = typeof(Bottle).GetProperty("Liquid");
+            Assert.IsTrue(propertyInfo.CanRead);
+        }
+
+        [TestMethod]
+        public void Bottle_Can_Write_Message()
+        {
+            var propertyInfo = typeof(Bottle).GetProperty("Liquid");
+            Assert.IsTrue(propertyInfo.CanWrite);
+        }
+
+        [TestMethod]
+        public void Bottle_Can_Fill()
+        {
+            Bottle bottle = Activator.CreateInstance(typeof(Bottle)) as Bottle;
+            MethodInfo bottleMessage = bottle.GetType().GetMethods().Single(m => m.Name == "Fill");
+            var bottleMessageResult = bottleMessage.Invoke(bottle, null);
+            Assert.AreEqual("You have filled the bottle with !", bottleMessageResult);
+        }
+    }
+}

--- a/Reflection/Reflection/ReflectionTests/Properties/AssemblyInfo.cs
+++ b/Reflection/Reflection/ReflectionTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ReflectionTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ReflectionTests")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("94edfbc2-4acd-42b7-ba05-76a6aca14c85")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Reflection/Reflection/ReflectionTests/ReflectionTests.csproj
+++ b/Reflection/Reflection/ReflectionTests/ReflectionTests.csproj
@@ -1,0 +1,90 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{94EDFBC2-4ACD-42B7-BA05-76A6ACA14C85}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ReflectionTests</RootNamespace>
+    <AssemblyName>ReflectionTests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="BottleReflectionTests.cs" />
+    <Compile Include="StampReflectionTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Reflection\Reflection.csproj">
+      <Project>{8bd4a077-237b-4e0d-a7fa-8adf53655668}</Project>
+      <Name>Reflection</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Reflection/Reflection/ReflectionTests/StampReflectionTests.cs
+++ b/Reflection/Reflection/ReflectionTests/StampReflectionTests.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.CodeDom;
+using System.CodeDom.Compiler;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Microsoft.CSharp;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Reflection;
+
+namespace ReflectionTests
+{
+    [TestClass]
+    public class StampReflectionTests
+    {
+        [TestMethod]
+        public void Stamp_Can_Be_Constructed()
+        {
+            Stamp stamp = Activator.CreateInstance(typeof(Stamp)) as Stamp;
+            Assert.IsInstanceOfType(stamp, typeof(Stamp));
+        }
+
+        [TestMethod]
+        public void Stamp_Can_Write_IsInked()
+        {
+            var propertyInfo = typeof(Stamp).GetProperty("IsInked");
+            Assert.IsTrue(propertyInfo.CanWrite);
+        }
+
+        [TestMethod]
+        public void Stamp_Can_Read_IsInked()
+        {
+            var propertyInfo = typeof(Stamp).GetProperty("IsInked");
+            Assert.IsTrue(propertyInfo.CanRead);
+        }
+
+        [TestMethod]
+        public void Stamp_Can_Read_Message()
+        {
+            var propertyInfo = typeof(Stamp).GetProperty("Message");
+            Assert.IsTrue(propertyInfo.CanRead);
+        }
+
+        [TestMethod]
+        public void Stamp_Can_Write_Message()
+        {
+            var propertyInfo = typeof(Stamp).GetProperty("Message");
+            Assert.IsTrue(propertyInfo.CanWrite);
+        }
+
+        [TestMethod]
+        public void Stamp_Can_Stamp_Message()
+        {
+            Stamp stamp = Activator.CreateInstance(typeof(Stamp)) as Stamp;
+            MethodInfo stampMessage = stamp.GetType().GetMethods().Single(m => m.Name == "StampMessage");
+            var stampMessageResult = stampMessage.Invoke(stamp, null);
+            Assert.AreEqual("", stampMessageResult);
+        }
+
+    }
+}


### PR DESCRIPTION
…bjects via reflection.

For some strange reason I spend over an hour trying to troubleshoot, when accessing objects in another project the compiler likes to clean things up. Even if you instantiate a public class with private properties, type.GetProperties() will return an empty array. I eventually gave up on trying to make visual studio show these to me, and as the assignment description doesn't require us to have private/internal properties or classes, I simply went ahead and accessed public properties and methods via reflection.